### PR TITLE
Move Name_UUID search box to dashboard

### DIFF
--- a/schema-lab/src/dashboard/tasks/TasksList.jsx
+++ b/schema-lab/src/dashboard/tasks/TasksList.jsx
@@ -128,11 +128,14 @@ const TaskList = () => {
 
     // Get the amount of filtered elements found
     const findFilteredTokens = () => {
-        const { count } = taskData;
-        if (count === 0) {
-            return <div class="alert alert-warning text-center" role="alert">Your search <b>{token}</b> did not match any task!</div>
+        if (taskData) {
+            const { count } = taskData;
+            if (count === 0) {
+                return <div class="alert alert-warning text-center" role="alert">Your search <b>{token}</b> did not match any task!</div>
+            }
+        } else {
+            return null
         }
-        return null
      }
 
     return <Row className="p-3 mb-5">


### PR DESCRIPTION
In particular, this commit does the following:
* Adds an input box alognside with UUID label.
* Filters the Tasks with the UUID keyword. Filtering is applied on Enter key pushed. Furtheremore, Tasks rendering is restored to default with an empty keyword.
* Enables Tasks' filtering to be independent of the rendered page (index).
* Adds a static placeholder for pagination component to avoid floating results table.
* Adds an alert message when filtering with an invalid UUID.
* Removes UUID filtering from pop-up window.