### PR TITLE
Update SCHEMA lab with changes on SCHEMA api

### DIFF
--- a/schema-lab/src/dashboard/tasks/TaskStatus.jsx
+++ b/schema-lab/src/dashboard/tasks/TaskStatus.jsx
@@ -18,6 +18,7 @@ const TaskStatus = (props) => {
             icon = faFileCircleXmark;
             break;
         case "SCHEDULED":
+        case "QUEUED":
             icon = faStopwatch;
             color = "text-success";
             break;

--- a/schema-lab/src/dashboard/tasks/TasksList.jsx
+++ b/schema-lab/src/dashboard/tasks/TasksList.jsx
@@ -332,6 +332,7 @@ const TaskList = () => {
                                         <Dropdown.Item eventKey='submitted'><TaskStatus status='SUBMITTED' /></Dropdown.Item>
                                         <Dropdown.Item eventKey='approved'><TaskStatus status='APPROVED' /></Dropdown.Item>
                                         <Dropdown.Item eventKey='scheduled'><TaskStatus status='SCHEDULED' /></Dropdown.Item>
+                                        <Dropdown.Item eventKey='queued'><TaskStatus status='QUEUED' /></Dropdown.Item>
                                         <Dropdown.Item eventKey='running'><TaskStatus status='RUNNING' /></Dropdown.Item>
                                         <Dropdown.Item eventKey='completed'><TaskStatus status='COMPLETED' /></Dropdown.Item>
                                         <Dropdown.Item eventKey='error'><TaskStatus status='ERROR' /></Dropdown.Item>

--- a/schema-lab/src/dashboard/tasks/TasksList.jsx
+++ b/schema-lab/src/dashboard/tasks/TasksList.jsx
@@ -351,9 +351,9 @@ const TaskList = () => {
                                 <TaskListing
                                     key={task.uuid}
                                     uuid={task.uuid}
-                                    status={task.state.status}
+                                    status={task.current_status.status}
                                     submitted_at={task.submitted_at}
-                                    updated_at={task.state.updated_at}
+                                    updated_at={task.current_status.updated_at}
                                     showWorkflowTasks={showWorkflowTasks}
                                 />
                             ))}

--- a/schema-lab/src/dashboard/tasks/details/TaskListDetails.jsx
+++ b/schema-lab/src/dashboard/tasks/details/TaskListDetails.jsx
@@ -49,7 +49,7 @@ const TaskListDetails = () => {
                     ...prev,
                     name: data.name,
                     execution_order: data.execution_order,
-                    status: data.state?.[data.state.length - 1]?.status || "Unknown",
+                    status: data.status_history?.[data.status_history.length - 1]?.status || "Unknown",
                     executors: data.executors,
                     inputs: data.inputs,
                     outputs: data.outputs,

--- a/schema-lab/src/dashboard/tasks/expriment/create/CreateExperiment.jsx
+++ b/schema-lab/src/dashboard/tasks/expriment/create/CreateExperiment.jsx
@@ -157,9 +157,9 @@ const CreateExperiment = () => {
                                                     <td>
                                                         <Link to={`/task-details/${task.uuid}/executors`}>{task.uuid}</Link>
                                                     </td>
-                                                    <td><TaskStatus status={task.state.status} /></td>
+                                                    <td><TaskStatus status={task.current_status.status} /></td>
                                                     <td>{new Date(task.submitted_at).toLocaleString('en')}</td>
-                                                    <td>{new Date(task.state.updated_at).toLocaleString('en')}</td>
+                                                    <td>{new Date(task.current_status.updated_at).toLocaleString('en')}</td>
                                                 </tr>
                                             ))
                                         )}

--- a/schema-lab/src/dashboard/tasks/expriment/details/ExperimentDetails.jsx
+++ b/schema-lab/src/dashboard/tasks/expriment/details/ExperimentDetails.jsx
@@ -119,9 +119,9 @@ const ExperimentDetails = () => {
                                                             to={`/task-details/${task.uuid}/executors`} state={{ from: 'experiments', creator: `${experimentDetails.creator}`, name: `${experimentDetails.name}` }}>
                                                             {task.uuid}</Link>
                                                         </td>
-                                                        <td><TaskStatus status={task.state.status} /></td>
+                                                        <td><TaskStatus status={task.current_status.status} /></td>
                                                         {/* <td>{new Date(task.submitted_at).toLocaleString('en')}</td> */}
-                                                        <td>{new Date(task.state.updated_at).toLocaleString('en')}</td>
+                                                        <td>{new Date(task.current_status.updated_at).toLocaleString('en')}</td>
                                                     </tr>
                                                 ))
                                             )}

--- a/schema-lab/src/dashboard/tasks/expriment/view/TasksList.jsx
+++ b/schema-lab/src/dashboard/tasks/expriment/view/TasksList.jsx
@@ -259,9 +259,9 @@ const ExperimentTaskList = () => {
                                 <ExperimentTaskListing
                                     key={task.uuid}
                                     uuid={task.uuid}
-                                    status={task.state.status}
+                                    status={task.current_status.status}
                                     submitted_at={task.submitted_at}
-                                    updated_at={task.state.updated_at}
+                                    updated_at={task.current_status.updated_at}
                                     isSelected={selectedTasks.some(t => t.uuid === task.uuid)}
                                     toggleSelection={() => toggleRowSelection(task)}
                                 />


### PR DESCRIPTION
- Update status history lists with new API field names that reflect better the returned payload. 

  - In the case where a workflow or a task's details are returned, the corresponding status history appears under the property `status_history` (former `state`).
  - For listing response payloads, where only the latest/current status is returned, that appears under the property `current_status` (former `state`).

- Integrate new status value, `QUEUED` - allow displaying and filtering.